### PR TITLE
DMに日本時間の送信日時を表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+<!-- 
+#ER図
 
-Things you may want to cover:
+## itemsテーブル
 
-* Ruby version
+|Column|Type|Options|
+|------|----|-------|
+|id|integer||
+|name|string|null: false|
+|price|integer|null: false|
+|introduce|text|null: false|
+|user_id|integer|null: false,foreign_key: true|
+|brand_id|integer|foreign_key: true|
+|size_id|integer|foreign_key: true|
+|commodity_condition_id|integer|foreign_key: true|
+|shippig_charge_id|integer|foreign_key: true|
+|shippig_method_id|integer|foreign_key: true|
+|prefecture_id|integer|null: false|
+|shippig_day_id|integer|foreign_key: true|
+|purchase|integer||
+|buyer|integer||
 
-* System dependencies
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :user
+- belongs_to :category
+<!-- - belongs_to :size -->
+<!-- - belongs_to :commodoty_condition -->
+- belongs_to :brand
+<!-- - belongs_to :shipping_charge -->
+<!-- - belongs_to :shipping_mathod -->
+<!-- - belongs_to :shipping_day -->
+- has_many :item_images dependent: :destroy
+- belongs_to_active_hash: prefecture
+- belongs_to_active_hash: commodity_condition
+- belongs_to_active_hash: shipping_method
+- belongs_to_active_hash :shipping_day
+- belongs_to_active_hash :shipping_charge
+- belongs_to_active_hash :size -->

--- a/app/assets/stylesheets/modules/_dm.scss
+++ b/app/assets/stylesheets/modules/_dm.scss
@@ -24,12 +24,15 @@
       &__user_name {
         a {
           color: #ffffff;
-          font-size: 1.2rem;
+          font-size: 1.4rem;
           text-decoration: none;
         }
         a:hover {
           color: rgba( 255, 255, 255, 0.6);
         }
+      }
+      &__date {
+        font-size: 1rem;
       }
       &__text {
         display: inline-block;

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -14,6 +14,8 @@
             .message__user_name
               = link_to user_path(message.user_id) do
                 = message.user.name
+            .message__date
+              = message.created_at
             .message__text
               = message.text
         - else
@@ -21,6 +23,8 @@
             .message__user_name
               = link_to user_path(message.user_id) do
                 = message.user.name
+            .message__date
+              = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
             .message__text
               = message.text
     - else


### PR DESCRIPTION
#What
DM画面でメッセージに送信時刻を表示するように編集した。
（日本時間）


#Why
ユーザーにとって送信時刻は必要な情報であるため