### PR TITLE
hedder-badg

### DIFF
--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -57,6 +57,9 @@
         span:hover {
           color: rgba( 255, 255, 255, 0.6);
         }
+        .add_badg {
+          border-bottom: 1px solid red;
+        }
         .my-lists {
           display: none;
           width: 150px;
@@ -107,6 +110,18 @@
       }
     }
   }
+}
+
+.dm_badg {
+  display: flex;
+  align-items: center;
+}
+
+.all-new-message-badge {
+  background: rgba(255, 0, 0, 0.6);
+  border-radius: 25%;
+  padding: 5px;
+  font-size: 1.2rem;
 }
 
 @media (max-width:599px){

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,19 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :all_new_messages
+
+  def all_new_messages
+    if user_signed_in?
+      receive_user = Message.where(receive_user_id: current_user.id).count
+      receive_user_checked_message = Message.where(receive_user_id_checked_message: current_user.id).count
+      message_count = receive_user - receive_user_checked_message
+      if 0 == message_count
+        @badg = 0
+      else
+        @badg = 1
+      end
+    end
+  end
 
   protected
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,15 @@ module ApplicationHelper
       content_tag(:div, message_count, class: 'new-message-badge')
     end
   end
+
+    def all_new_message_badga
+      receive_user = Message.where(receive_user_id: current_user.id).count
+      receive_user_checked_message = Message.where(receive_user_id_checked_message: current_user.id).count
+      message_count = receive_user - receive_user_checked_message
+      if 0 == message_count
+      else
+        content_tag(:div, message_count, class: 'all-new-message-badge')
+      end
+    end
+
 end

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -7,15 +7,29 @@
       #Navber
         - if user_signed_in?
           .nav-name-post
-            %span<
-              = current_user.name
-              %ul.my-lists><
-                %li.my-list><
-                  = link_to "マイページ", user_path(current_user)
-                  = link_to "DM", rooms_path
-                  = link_to 'プロフィール編集', profile_edit_path
-                  = link_to "メール & PW編集", edit_user_registration_path
-                  = link_to "ログアウト", destroy_user_session_path, method: :delete
+            - if @badg == 0
+              %span.no_badg<
+                = current_user.name
+                %ul.my-lists><
+                  %li.my-list><
+                    = link_to "マイページ", user_path(current_user)
+                    = link_to "DM", rooms_path, class: "new_message"
+                    = all_new_message_badga
+                    = link_to 'プロフィール編集', profile_edit_path
+                    = link_to "メール & PW編集", edit_user_registration_path
+                    = link_to "ログアウト", destroy_user_session_path, method: :delete
+            - else
+              %span.add_badg<
+                = current_user.name
+                %ul.my-lists><
+                  %li.my-list><
+                    = link_to "マイページ", user_path(current_user)
+                    .dm_badg
+                      = link_to "DM", rooms_path
+                      = all_new_message_badga
+                    = link_to 'プロフィール編集', profile_edit_path
+                    = link_to "メール & PW編集", edit_user_registration_path
+                    = link_to "ログアウト", destroy_user_session_path, method: :delete
             = link_to "投稿する", new_memory_path, class: "post-photo"
         - else
           %ul.navbar-nav


### PR DESCRIPTION
#20 What
ヘッダー上部のログインユーザー名に、未獄のDMがあればアンダーラインが引かれて、ユーザに知らせるよう変更。
また、DMボタンにトータル未読件数を表示

#Why
未読メッセージがあってもトップページからでは気づく事ができないため