### PR TITLE
room.entriesをwhereによる条件分岐

### DIFF
--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -11,11 +11,9 @@ module RoomsHelper
   end
 
   def opponent_user(room)
-    entries = room.entries
-    entries.each do |entry|
-     @name = entry.user.name unless current_user.id == entry.user_id
-    end
-    tag.p "#{@name}", class: "dm_list__content__link__box__name"
+    entry = room.entries.where.not(user_id: current_user)
+    name = entry[0].user.name
+    tag.p "#{name}", class: "dm_list__content__link__box__name"
 
   end
 

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -2,9 +2,8 @@ module RoomsHelper
 
   def most_new_message_preview(room)
     message = room.messages.order(updated_at: :desc).limit(1)
-    message = message[0]
     if message.present?
-      tag.p "#{message.text}", class: "dm_list__content__link__box__message"
+      tag.p "#{message[0].text}", class: "dm_list__content__link__box__message"
     else
       tag.p "[ まだメッセージはありません ]", class: "dm_list__content__link__box__message"
     end
@@ -12,8 +11,7 @@ module RoomsHelper
 
   def opponent_user(room)
     entry = room.entries.where.not(user_id: current_user)
-    name = entry[0].user.name
-    tag.p "#{name}", class: "dm_list__content__link__box__name"
+    tag.p "#{entry[0].user.name}", class: "dm_list__content__link__box__name"
 
   end
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -2,16 +2,6 @@
   Photographer
 
 = render partial: '/shared/search_form'
--# .camera_boxes
--#   - @users.each do |user|
--#     .camera_contents
--#       - if current_user.id != user.id
--#         = link_to user_path(user.id), class: "camera_link" do
--#           .camera_box
--#             .mini-prf-image-box
--#               = image_tag user.image.url, class: 'mini-prf-image'
--#             %p.camera_name
--#               = user.name
 .user-contants
   = render partial: 'shared/user', collection: @users
   = paginate @users


### PR DESCRIPTION
#What
opponent_userメソッドでログインユーザー以外の情報を取得している。
以前はroom.entriesで全てのデータを取得し、その後条件分岐させていたところを、where.notを使用し、条件分岐をなくした。

#Why
コードを短くし、可読性の向上。
メンテナンスをしやすく。
